### PR TITLE
Clarify definition of Covarsky

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Covarsky
 
-Covarsky is a tool that brings covariant and contravariant generic types to .ΝΕΤ languages that do not natively support them like F#. Powered by [Sigourney], it runs an MSBuild task that modifies the assembly after compilation.
+Covarsky is a tool that brings covariant and contravariant generic types to .ΝΕΤ languages, like F#, that do not already natively support them. Powered by [Sigourney], it runs an MSBuild task that modifies the assembly after compilation.
 
 ## How to use
 


### PR DESCRIPTION
The first sentence was a bit ambiguous; I first read it as meaning Covarsky added its features to dotnet languages that don't have them, with F# being an example of one that does! Completely the wrong way round. Maybe it's just me who would do that, but I think the change removes the possibility of that interpretation.